### PR TITLE
Update base url for prod

### DIFF
--- a/web/app/lib/chart/override/postgresql.rb
+++ b/web/app/lib/chart/override/postgresql.rb
@@ -3,7 +3,7 @@
 class Chart::Override::Postgresql < Chart::Override::Base
   # https://artifacthub.io/packages/helm/bitnami/postgresql
   OVERRIDE_MAP = {
-    db_name: %w[primary.database],
+    db_name: %w[auth.database],
     db_user: %w[auth.username],
     db_password: %w[auth.password],
     cpu_cores: %w[primary.resources.requests.cpu primary.resources.limits.cpu],

--- a/web/app/models/concerns/dependency_rpc.rb
+++ b/web/app/models/concerns/dependency_rpc.rb
@@ -6,6 +6,7 @@ module DependencyRPC
   def rpc_dependency
     Sidecar::DependencyParams.new(
       name: chart_name,
+      values_alias: name,
       version:,
       repository_url: repo_url,
       overrides: rpc_overrides

--- a/web/app/models/helm_repo.rb
+++ b/web/app/models/helm_repo.rb
@@ -74,7 +74,7 @@ class HelmRepo < ApplicationRecord
     # TODO: this does not belong here
     return "http://localhost:3000" if Rails.env.development? || Rails.env.test?
 
-    "https://vpc.context.ai"
+    "https://app.trustshepherd.com"
   end
 
   def bucket

--- a/web/spec/models/project_version_spec.rb
+++ b/web/spec/models/project_version_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ProjectVersion do
           Sidecar::OverrideParams.new(path: 'primary.resources.requests.memory', value: Google::Protobuf::Value.new(number_value: 4294967296.0)),
           Sidecar::OverrideParams.new(path: 'primary.resources.limits.memory', value: Google::Protobuf::Value.new(number_value: 4294967296.0)),
           Sidecar::OverrideParams.new(path: 'primary.persistence.size', value: Google::Protobuf::Value.new(number_value: 5368709120.0)),
-          Sidecar::OverrideParams.new(path: 'primary.database', value: Google::Protobuf::Value.new(string_value: 'test_db')),
+          Sidecar::OverrideParams.new(path: 'auth.database', value: Google::Protobuf::Value.new(string_value: 'test_db')),
           Sidecar::OverrideParams.new(path: 'auth.username', value: Google::Protobuf::Value.new(string_value: 'test_user')),
           Sidecar::OverrideParams.new(path: 'auth.password', value: Google::Protobuf::Value.new(string_value: 'test_pass'))
         )
@@ -204,7 +204,7 @@ RSpec.describe ProjectVersion do
         Sidecar::OverrideParams.new(path: 'primary.resources.requests.memory', value: Google::Protobuf::Value.new(number_value: 4294967296.0)),
         Sidecar::OverrideParams.new(path: 'primary.resources.limits.memory', value: Google::Protobuf::Value.new(number_value: 4294967296.0)),
         Sidecar::OverrideParams.new(path: 'primary.persistence.size', value: Google::Protobuf::Value.new(number_value: 5368709120.0)),
-        Sidecar::OverrideParams.new(path: 'primary.database', value: Google::Protobuf::Value.new(string_value: 'test_db')),
+        Sidecar::OverrideParams.new(path: 'auth.database', value: Google::Protobuf::Value.new(string_value: 'test_db')),
         Sidecar::OverrideParams.new(path: 'auth.username', value: Google::Protobuf::Value.new(string_value: 'test_user')),
         Sidecar::OverrideParams.new(path: 'auth.password', value: Google::Protobuf::Value.new(string_value: 'test_pass'))
       )


### PR DESCRIPTION
update grpc dependency object to use values_alias.

Fix override for db in postresql going to primary database instead of auth database

Fixes CTX-537