### PR TITLE
Make edit page for services viewable after deployment

### DIFF
--- a/web/app/components/services/cpu_slider_component.html.erb
+++ b/web/app/components/services/cpu_slider_component.html.erb
@@ -1,6 +1,7 @@
 <%= render UI::StepSliderComponent.new(
   form:,
   steps: options_value,
+  disabled:,
   labels: options_value.map { |m| pluralize(m, 'core') },
   name: :cpu_cores
 ) %>

--- a/web/app/components/services/cpu_slider_component.rb
+++ b/web/app/components/services/cpu_slider_component.rb
@@ -2,6 +2,7 @@
 
 class Services::CPUSliderComponent < ApplicationComponent
   attribute :form
+  attribute :disabled, default: false
 
   DEFAULT_OPTIONS = [
     1, 2, 4, 8, 16, 32

--- a/web/app/components/services/disk_slider_component.html.erb
+++ b/web/app/components/services/disk_slider_component.html.erb
@@ -1,6 +1,7 @@
 <%= render UI::StepSliderComponent.new(
   form:,
   steps: options_value,
+  disabled:,
   labels: options_value.map { |m| number_to_human_size(m) },
   name: :disk_bytes
 ) %>

--- a/web/app/components/services/disk_slider_component.rb
+++ b/web/app/components/services/disk_slider_component.rb
@@ -2,6 +2,7 @@
 
 class Services::DiskSliderComponent < ApplicationComponent
   attribute :form
+  attribute :disabled, default: false
 
   DEFAULT_OPTIONS = [
     1.gigabytes, 5.gigabytes, 10.gigabytes, 50.gigabytes, 100.gigabytes, 500.gigabytes, 1.terabyte, 5.terabytes

--- a/web/app/components/services/element_component.html.erb
+++ b/web/app/components/services/element_component.html.erb
@@ -1,9 +1,6 @@
 <li class="grid items-stretch">
   <% block_content = capture do %>
-    <%= content_tag :div, class: ['w-full border border-solid border-stone-400 p-4 duration-200 flex flex-col gap-4 bg-white z-2', {
-      'cursor-pointer hover:shadow-md': enabled?,
-      'cursor-not-allowed opacity-70': !enabled?
-    }] do %>
+    <%= content_tag :div, class: 'cursor-pointer hover:shadow-md w-full border border-solid border-stone-400 p-4 duration-200 flex flex-col gap-4 bg-white z-2' do %>
       <div class="flex justify-between items-center">
         <h6 class="flex items-center gap-2">
           <%= heroicon "squares-2x2", class: "size-4" %>
@@ -27,11 +24,7 @@
     <% end %>
   <% end %>
 
-  <% if enabled? %>
-    <%= link_to edit_project_service_path(service), class: '' do %>
-      <%= block_content %>
-    <% end %>
-  <% else %>
+  <%= link_to edit_project_service_path(service), class: '' do %>
     <%= block_content %>
   <% end %>
 </li>

--- a/web/app/components/services/element_component.rb
+++ b/web/app/components/services/element_component.rb
@@ -3,8 +3,4 @@
 class Services::ElementComponent < ApplicationComponent
   attribute :service
   attribute :version
-
-  def enabled?
-    version.draft?
-  end
 end

--- a/web/app/components/services/environment_variable_component.html.erb
+++ b/web/app/components/services/environment_variable_component.html.erb
@@ -1,13 +1,17 @@
 <div class="dynamic-element flex gap-4 items-center">
   <%# hidden value for now as we will not support this yet %>
-  <%= form.hidden_field :templated, value: '0' %>
+  <%= form.hidden_field :templated, disabled:, value: '0' %>
   <%= form.text_field :name,
-                      placeholder: 'ENVIRONMENT_VARIABLE',
-                      class: 'text-sm w-2/6 text-input'
+                      placeholder: disabled ? nil : 'ENVIRONMENT_VARIABLE',
+                      disabled:,
+                      class: ['text-sm w-2/6 text-input', { '!bg-stone-100 opacity-90 cursor-not-allowed': disabled }]
   %>
   <%= form.text_field :value,
-                      placeholder: 'value',
-                      class: 'text-sm w-4/6 text-input'
+                      placeholder: disabled ? nil : 'value',
+                      disabled:,
+                      class: ['text-sm w-4/6 text-input', { '!bg-stone-100 opacity-90 cursor-not-allowed': disabled }]
   %>
-    <%= heroicon "minus-circle", class: 'flex-none size-6 text-red-600 cursor-pointer', data: { action: 'click->dynamic-nested-form-form-component#removeSubform' } %>
+  <%= heroicon "minus-circle",
+               class: 'flex-none size-6 text-red-600 cursor-pointer',
+               data: { action: 'click->dynamic-nested-form-form-component#removeSubform' } unless disabled %>
 </div>

--- a/web/app/components/services/environment_variable_component.rb
+++ b/web/app/components/services/environment_variable_component.rb
@@ -2,4 +2,5 @@
 
 class Services::EnvironmentVariableComponent < ApplicationComponent
   attribute :form
+  attribute :disabled, default: false
 end

--- a/web/app/components/services/form_disk_component.html.erb
+++ b/web/app/components/services/form_disk_component.html.erb
@@ -12,16 +12,23 @@
     </div>
 
     <div class="<%= 'hidden' if existing_mount? %> w-full flex justify-end" data-expandable-form-target="addButton">
-      <div class="button flex items-center gap-1" data-action="click->expandable-form#showSubForm">
-        <%= heroicon :plus, class: 'size-4' %>
-        Add Disk
-      </div>
+      <% if disabled %>
+        <div class="flex items-center gap-1 opacity-90 cursor-not-allowed bg-stone-100 select-none text-sm border px-2 py-1 text-stone-700 shadow-sm max-h-8 h-12 border-stone-300">
+          <%= heroicon :plus, class: 'size-4' %>
+          Add Disk
+        </div>
+      <% else %>
+        <div class="button flex items-center gap-1" data-action="click->expandable-form#showSubForm">
+          <%= heroicon :plus, class: 'size-4' %>
+          Add Disk
+        </div>
+      <% end %>
     </div>
   </div>
 
   <div class="<%= 'hidden' unless existing_mount? %> flex flex-col gap-8" data-expandable-form-target="subForm">
 
-    <%= render UI::FormTextFieldComponent.new(title: 'Mount Path') do |component| %>
+    <%= render UI::FormTextFieldComponent.new(title: 'Mount Path', disabled:) do |component| %>
       <%= component.with_label do %>
         The absolute path where the disk will be mounted inside the container.
       <% end %>
@@ -31,9 +38,9 @@
                             pattern: "\/(?!\/$)(?!\/+)[\w.-]+(?:\/[\w.-]+)*\/?",
                             title: 'Path must be a valid absolute path (not root)',
                             placeholder: '/var/data',
-                            disabled: !existing_mount?,
+                            disabled: !existing_mount? || disabled,
                             'data-expandable-form-target': 'formField',
-                            class: 'text-sm w-full !p-0 border-0 focus:ring-0' %>
+                            class: ['text-sm w-full !p-0 border-0 focus:ring-0 bg-transparent', { 'cursor-not-allowed': disabled }] %>
       <% end %>
     <% end %>
 
@@ -51,7 +58,7 @@
           steps: options_value,
           labels: options_value.map { |m| number_to_human_size(m) },
           name: :pvc_size_bytes,
-          disabled: !existing_mount?,
+          disabled: !existing_mount? || disabled,
           form_attributes: { 'data-expandable-form-target': 'formField' }
           ) %>
       </div>
@@ -59,9 +66,15 @@
 
 
     <div class="w-full flex justify-end">
-      <div class="border bg-red-700 text-white p-2 cursor-pointer w-fit text-sm" data-action="click->expandable-form#hideSubForm">
-        Remove Disk
-      </div>
+      <% if disabled %>
+        <div class="border bg-red-600 text-white p-2 cursor-not-allowed w-fit text-sm opacity-70">
+          Remove Disk
+        </div>
+      <% else %>
+        <div class="border bg-red-700 text-white p-2 cursor-pointer w-fit text-sm" data-action="click->expandable-form#hideSubForm">
+          Remove Disk
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/web/app/components/services/form_disk_component.rb
+++ b/web/app/components/services/form_disk_component.rb
@@ -2,6 +2,7 @@
 
 class Services::FormDiskComponent < ApplicationComponent
   attribute :form
+  attribute :disabled, default: false
 
   DEFAULT_OPTIONS = [
     1.gigabytes, 5.gigabytes, 10.gigabytes, 50.gigabytes, 100.gigabytes, 500.gigabytes

--- a/web/app/components/services/image_credentials_component.html.erb
+++ b/web/app/components/services/image_credentials_component.html.erb
@@ -12,16 +12,23 @@
     </div>
 
     <div class="<%= 'hidden' if existing_credentials? %> w-full flex justify-end" data-expandable-form-target="addButton">
-      <div class="button flex items-center gap-1" data-action="click->expandable-form#showSubForm">
-        <%= heroicon :plus, class: 'size-4' %>
-        Add Credentials
-      </div>
+      <% if disabled %>
+        <div class="flex items-center gap-1 opacity-90 cursor-not-allowed bg-stone-100 select-none text-sm border px-2 py-1 text-stone-700 shadow-sm max-h-8 h-12 border-stone-300">
+          <%= heroicon :plus, class: 'size-4' %>
+          Add Credentials
+        </div>
+      <% else %>
+        <div class="button flex items-center gap-1" data-action="click->expandable-form#showSubForm">
+          <%= heroicon :plus, class: 'size-4' %>
+          Add Credentials
+        </div>
+      <% end %>
     </div>
   </div>
 
   <div class="<%= 'hidden' unless existing_credentials? %> flex flex-col gap-8" data-expandable-form-target="subForm">
 
-    <%= render UI::FormTextFieldComponent.new(title: 'Username') do |component| %>
+    <%= render UI::FormTextFieldComponent.new(title: 'Username', disabled:) do |component| %>
       <%= component.with_label do %>
         Docker hub username.
       <% end %>
@@ -29,13 +36,13 @@
         <%= form.text_field :image_username,
                             required: true,
                             placeholder: 'Username',
-                            disabled: !existing_credentials?,
+                            disabled: !existing_credentials? || disabled,
                             'data-expandable-form-target': 'formField',
-                            class: 'text-sm w-full !p-0 border-0 focus:ring-0' %>
+                            class: ['text-sm w-full !p-0 border-0 focus:ring-0 bg-transparent', { 'cursor-not-allowed': disabled }] %>
       <% end %>
     <% end %>
 
-    <%= render UI::FormTextFieldComponent.new(title: 'Password') do |component| %>
+    <%= render UI::FormTextFieldComponent.new(title: 'Password', disabled:) do |component| %>
       <%= component.with_label do %>
         Docker hub password or Personal Access Token.
       <% end %>
@@ -43,16 +50,24 @@
         <%= form.text_field :image_password,
                             required: true,
                             placeholder: 'Password',
-                            disabled: !existing_credentials?,
+                            disabled: !existing_credentials? || disabled,
                             'data-expandable-form-target': 'formField',
-                            class: 'text-sm w-full !p-0 border-0 focus:ring-0' %>
+                            class: ['text-sm w-full !p-0 border-0 focus:ring-0 bg-transparent', { 'cursor-not-allowed': disabled }] %>
       <% end %>
     <% end %>
 
-    <div class="w-full flex justify-end">
-      <div class="border bg-red-700 text-white p-2 cursor-pointer w-fit text-sm" data-action="click->expandable-form#hideSubForm">
-        Remove Credentials
+    <% if disabled %>
+      <div class="w-full flex justify-end">
+        <div class="border bg-red-600 text-white p-2 cursor-not-allowed w-fit text-sm opacity-70">
+          Remove Credentials
+        </div>
       </div>
-    </div>
+    <% else %>
+      <div class="w-full flex justify-end">
+        <div class="border bg-red-700 text-white p-2 cursor-pointer w-fit text-sm" data-action="click->expandable-form#hideSubForm">
+          Remove Credentials
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/web/app/components/services/image_credentials_component.rb
+++ b/web/app/components/services/image_credentials_component.rb
@@ -2,6 +2,7 @@
 
 class Services::ImageCredentialsComponent < ApplicationComponent
   attribute :form
+  attribute :disabled, default: false
 
   def existing_credentials?
     form.object.image_username.present? || form.object.image_password.present?

--- a/web/app/components/services/memory_slider_component.html.erb
+++ b/web/app/components/services/memory_slider_component.html.erb
@@ -1,6 +1,7 @@
 <%= render UI::StepSliderComponent.new(
   form:,
   steps: options_value,
+  disabled:,
   labels: options_value.map { |m| number_to_human_size(m) },
   name: :memory_bytes
 ) %>

--- a/web/app/components/services/memory_slider_component.rb
+++ b/web/app/components/services/memory_slider_component.rb
@@ -2,6 +2,7 @@
 
 class Services::MemorySliderComponent < ApplicationComponent
   attribute :form
+  attribute :disabled, default: false
 
   DEFAULT_OPTIONS = [
     1, 2, 4, 8, 16, 32, 64

--- a/web/app/components/services/port_component.html.erb
+++ b/web/app/components/services/port_component.html.erb
@@ -1,16 +1,24 @@
 <div class="dynamic-element flex gap-16 items-center">
   <div class="flex gap-8 items-center w-full">
     <%= form.text_field :port,
-                        placeholder: '80',
+                        disabled:,
+                        placeholder: disabled ? nil : '80',
                         pattern: '\d*',
                         title: 'Port must be a number between 1 and 65535',
                         min: 1,
                         max: 65535,
-                        class: 'text-sm text-input w-full' %>
+                        class: ['text-sm text-input w-full', { '!bg-stone-100 opacity-90 cursor-not-allowed': disabled }] %>
     <%= form.check_box :ingress,
+                       disabled:,
                        data: { "singular-checkbox-target": "checkbox", action: "change->singular-checkbox#check" },
-                       class: 'ring-0 focus:ring-0' %>
+                       class: ['ring-0 focus:ring-0', { '!bg-stone-100 opacity-90 cursor-not-allowed': disabled }] %>
   </div>
 
-  <%= heroicon "minus-circle", class: 'flex-none size-6 text-red-600 cursor-pointer', data: { action: 'click->dynamic-nested-form-form-component#removeSubform' } %>
+  <% if disabled %>
+    <div class="size-6"></div>
+  <% else %>
+    <%= heroicon "minus-circle",
+                 class: 'flex-none size-6 text-red-600 cursor-pointer',
+                 data: { action: 'click->dynamic-nested-form-form-component#removeSubform' } %>
+  <% end %>
 </div>

--- a/web/app/components/services/port_component.rb
+++ b/web/app/components/services/port_component.rb
@@ -2,4 +2,5 @@
 
 class Services::PortComponent < ApplicationComponent
   attribute :form
+  attribute :disabled, default: false
 end

--- a/web/app/components/services/secret_component.html.erb
+++ b/web/app/components/services/secret_component.html.erb
@@ -1,6 +1,10 @@
 <div class="dynamic-element flex gap-4 items-center">
   <%= form.text_field :name,
-                       placeholder: 'ENVIRONMENT_VARIABLE',
-                       class: 'text-sm w-full text-input' %>
-  <%= heroicon "minus-circle", class: 'flex-none size-6 text-red-600 cursor-pointer', data: { action: 'click->dynamic-nested-form-form-component#removeSubform' } %>
+                       disabled:,
+                       placeholder: disabled ? nil : 'ENVIRONMENT_VARIABLE',
+                       class: ['text-sm w-full text-input', { '!bg-stone-100 opacity-90 cursor-not-allowed': disabled }] %>
+
+  <%= heroicon "minus-circle",
+               class: 'flex-none size-6 text-red-600 cursor-pointer',
+               data: { action: 'click->dynamic-nested-form-form-component#removeSubform' } unless disabled %>
 </div>

--- a/web/app/components/services/secret_component.rb
+++ b/web/app/components/services/secret_component.rb
@@ -2,4 +2,5 @@
 
 class Services::SecretComponent < ApplicationComponent
   attribute :form
+  attribute :disabled, default: false
 end

--- a/web/app/components/services/service_form_component.html.erb
+++ b/web/app/components/services/service_form_component.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: service_object, url:, method: form_method do |form| %>
   <%= form.hidden_field :service_id, value: service_object.service_id  %>
   <div class="flex flex-col gap-6">
-    <%= render UI::FormTextFieldComponent.new(title: 'Name') do |component| %>
+    <%= render UI::FormTextFieldComponent.new(title: 'Name', disabled:) do |component| %>
       <%= component.with_label do %>
         Unique within the project. Must be lower case and contain only letters, numbers, and hyphens with no spaces.
       <% end %>
@@ -9,31 +9,33 @@
         <%= form.text_field :name,
                             placeholder: 'my-service',
                             required: true,
+                            disabled:,
                             'data-1p-ignore': true,
                             'data-lpignore': true,
-                            class: 'text-sm w-full !p-0 border-0 focus:ring-0' %>
+                            class: ['text-sm w-full !p-0 border-0 focus:ring-0 bg-transparent', { 'cursor-not-allowed': disabled }] %>
       <% end %>
     <% end %>
 
-    <%= render UI::FormTextFieldComponent.new(title: 'Image') do |component| %>
+    <%= render UI::FormTextFieldComponent.new(title: 'Image', disabled:) do |component| %>
       <%= component.with_label do %>
         Valid docker image url with version tag. <span class="font-mono">:latest</span> is not allowed.
       <% end %>
       <%= component.with_field do %>
         <%= form.text_field :image,
                             required: true,
+                            disabled:,
                             placeholder: 'docker.io/library/nginx:1.24.0-alpine3.17',
-                            class: 'text-sm w-full !p-0 border-0 focus:ring-0' %>
+                            class: ['text-sm w-full !p-0 border-0 focus:ring-0 bg-transparent', { 'cursor-not-allowed': disabled }] %>
       <% end %>
     <% end %>
 
     <hr class="border-stone-300 my-2">
 
-    <%= render Services::ImageCredentialsComponent.new(form:) %>
+    <%= render Services::ImageCredentialsComponent.new(form:, disabled:) %>
 
     <hr class="border-stone-300 my-2">
 
-    <%= render UI::FormResourcesComponent.new(form:, fields: %i[cpu memory]) %>
+    <%= render UI::FormResourcesComponent.new(form:, fields: %i[cpu memory], disabled:) %>
 
     <hr class="border-stone-300 my-2">
 
@@ -43,6 +45,7 @@
       form:,
       association_name: :environment_variables,
       vertical: true,
+      disabled:,
       model_class: Service::Form::EnvironmentVariableForm,
       child_component: Services::EnvironmentVariableComponent,
       ) do |component| %>
@@ -57,6 +60,7 @@
       title: 'Secrets',
       form:,
       caveat: :optional,
+      disabled:,
       association_name: :secrets,
       model_class: Service::Form::SecretForm,
       child_component: Services::SecretComponent,
@@ -69,7 +73,7 @@
 
     <hr class="border-stone-300 my-2">
 
-    <%= render UI::FormTextFieldComponent.new(title: 'Predeploy Command', caveat: :optional) do |component| %>
+    <%= render UI::FormTextFieldComponent.new(title: 'Predeploy Command', caveat: :optional, disabled:) do |component| %>
       <%= component.with_label do %>
         Command to run before deploying the service. For example, database migrations.
       <% end %>
@@ -77,15 +81,16 @@
         <div class="flex items-center gap-2">
           <span class="text-xs mt-0.5">$</span>
           <%= form.text_field :predeploy_command,
-                              placeholder: 'rake db:migrate',
-                              class: 'text-sm w-full !p-0 border-0 focus:ring-0' %>
+                              placeholder: disabled ? nil : 'rake db:migrate',
+                              disabled:,
+                              class: ['text-sm w-full !p-0 border-0 focus:ring-0 bg-transparent', { 'cursor-not-allowed': disabled }] %>
         </div>
       <% end %>
     <% end %>
 
     <hr class="border-stone-300 my-2">
 
-    <%= render Services::FormDiskComponent.new(form:, options: Service::Form::MOUNT_DISK_OPTIONS) %>
+    <%= render Services::FormDiskComponent.new(form:, options: Service::Form::MOUNT_DISK_OPTIONS, disabled:) %>
 
     <hr class="border-stone-300 my-2">
 
@@ -94,6 +99,7 @@
         title: 'Open Ports',
         caveat: :optional,
         form:,
+        disabled:,
         association_name: :ports,
         model_class: Service::Form::PortForm,
         child_component: Services::PortComponent,
@@ -113,6 +119,11 @@
       <% end %>
     </div>
 
-    <%= form.submit update_create_text, class: 'px-3 py-2 mt-2 bg-stone-700 text-stone-100 cursor-pointer w-fit' %>
+    <%= form.submit update_create_text,
+                    disabled:,
+                    class: [
+                      'px-3 py-2 mt-2 text-stone-100 w-fit',
+                      { 'cursor-pointer bg-stone-700': !disabled, 'cursor-not-allowed bg-stone-500 opacity-90': disabled }
+                    ] %>
   </div>
 <% end %>

--- a/web/app/components/services/service_form_component.rb
+++ b/web/app/components/services/service_form_component.rb
@@ -4,6 +4,7 @@ class Services::ServiceFormComponent < ApplicationComponent
   attribute :service_form_object
   attribute :form_method, default: :post
   attribute :version # hack, we can def remove this somehow.
+  attribute :disabled, default: false
 
   def service_object
     @service_object ||= service_form_object || Service::Form.empty

--- a/web/app/components/ui/form_multi_field_component.html.erb
+++ b/web/app/components/ui/form_multi_field_component.html.erb
@@ -23,7 +23,7 @@
         maximum_subforms: 10,
         ) do |component| %>
         <% component.with_subform_content do |secret_form| %>
-          <%= render child_component.new(form: secret_form) %>
+          <%= render child_component.new(form: secret_form, disabled:) %>
         <% end %>
       <% end %>
 
@@ -35,7 +35,7 @@
             + Add
           </div>
         <% end %>
-      <% end %>
+      <% end unless disabled %>
     </div>
   </div>
 </div>

--- a/web/app/components/ui/form_multi_field_component.rb
+++ b/web/app/components/ui/form_multi_field_component.rb
@@ -7,6 +7,8 @@ class UI::FormMultiFieldComponent < ApplicationComponent
   attribute :model_class
   attribute :vertical, default: false
 
+  attribute :disabled, default: false
+
   attribute :caveat, default: nil
 
   attribute :child_component

--- a/web/app/components/ui/form_resources_component.html.erb
+++ b/web/app/components/ui/form_resources_component.html.erb
@@ -4,19 +4,19 @@
     <% if fields.include? :cpu %>
       <div class="flex items-start grow w-full gap-8">
         <span class="font-medium w-16">CPU</span>
-        <%= render Services::CPUSliderComponent.new(form:, options: cpu_options) %>
+        <%= render Services::CPUSliderComponent.new(form:, options: cpu_options, disabled:) %>
       </div>
     <% end %>
     <% if fields.include? :memory %>
       <div class="flex items-start grow w-full gap-8">
         <span class="font-medium w-16">RAM</span>
-        <%= render Services::MemorySliderComponent.new(form:, options: memory_options) %>
+        <%= render Services::MemorySliderComponent.new(form:, options: memory_options, disabled:) %>
       </div>
     <% end %>
     <% if fields.include? :disk %>
       <div class="flex items-start grow w-full gap-8">
         <span class="font-medium w-16">Disk</span>
-        <%= render Services::DiskSliderComponent.new(form:, options: disk_options) %>
+        <%= render Services::DiskSliderComponent.new(form:, options: disk_options, disabled:) %>
       </div>
     <% end %>
   </div>

--- a/web/app/components/ui/form_resources_component.rb
+++ b/web/app/components/ui/form_resources_component.rb
@@ -6,4 +6,5 @@ class UI::FormResourcesComponent < ApplicationComponent
   attribute :memory_options
   attribute :cpu_options
   attribute :fields, default: %i[cpu memory disk]
+  attribute :disabled, default: false
 end

--- a/web/app/components/ui/form_text_field_component.html.erb
+++ b/web/app/components/ui/form_text_field_component.html.erb
@@ -11,7 +11,7 @@
     </span>
   </div>
 
-  <div class="text-sm w-7/12 text-input focus-within:ring-1 focus-within:ring-blue-500 focus-within:border-blue-500">
+  <div class="text-sm w-7/12 text-input focus-within:ring-1 focus-within:ring-blue-500 focus-within:border-blue-500 <%= 'opacity-80 !bg-stone-100 !border-stone-400 cursor-not-allowed' if disabled %>">
     <%= field %>
   </div>
 </div>

--- a/web/app/components/ui/form_text_field_component.rb
+++ b/web/app/components/ui/form_text_field_component.rb
@@ -3,6 +3,7 @@
 class UI::FormTextFieldComponent < ApplicationComponent
   attribute :title
   attribute :caveat
+  attribute :disabled, default: false
 
   renders_one :label
   renders_one :field

--- a/web/app/components/ui/step_slider_component.html.erb
+++ b/web/app/components/ui/step_slider_component.html.erb
@@ -9,6 +9,8 @@
                           min: 0,
                           max: steps.size - 1,
                           step: 1,
+                          disabled:,
+                          **form_attributes,
                           data: {
                             'step-slider-target': 'input',
                             'action': 'input->step-slider#slide',

--- a/web/app/controllers/project/service_controller.rb
+++ b/web/app/controllers/project/service_controller.rb
@@ -26,9 +26,16 @@ class Project::ServiceController < ApplicationController
     redirect_to version_path(@version)
   end
 
-  def edit; end
+  def edit
+    @disabled = @version.published?
+  end
 
   def update
+    if @version.published?
+      flash[:error] = "Service #{@service.name} cannot be updated"
+      return redirect_to edit_project_service_path(@version)
+    end
+
     unless form.valid?
       flash[:error] = form.errors.full_messages.first
       @service = form.build_service

--- a/web/app/views/project/service/edit.html.erb
+++ b/web/app/views/project/service/edit.html.erb
@@ -17,15 +17,17 @@
     </div>
   </div>
 
-  <%= render Services::ServiceFormComponent.new(service_form_object: Service::Form.from_service(@service), form_method: :patch) %>
+  <%= render Services::ServiceFormComponent.new(service_form_object: Service::Form.from_service(@service), form_method: :patch, disabled: @disabled) %>
 
-  <div class="flex flex-col gap-4 p-4 border-stone-300 border bg-white">
-    <div class="flex flex-col gap-1">
-      <span class="font-medium text-lg">Service Deletion</span>
-      <span class="text-stone-600 text-sm">Once you delete an Service, it cannot be undone. Please be absolutely certain before proceeding.</span>
+  <% unless @disabled %>
+    <div class="flex flex-col gap-4 p-4 border-stone-300 border bg-white">
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-lg">Service Deletion</span>
+        <span class="text-stone-600 text-sm">Once you delete an Service, it cannot be undone. Please be absolutely certain before proceeding.</span>
+      </div>
+      <%= button_to project_service_path(@service), method: :delete, class: 'button-destructive' do %>
+        Delete Service
+      <% end %>
     </div>
-    <%= button_to project_service_path(@service), method: :delete, class: 'button-destructive' do %>
-      Delete Service
-    <% end %>
-  </div>
+  <% end %>
 </div>


### PR DESCRIPTION
This pull request introduces a new `disabled` attribute to various service components, allowing them to be rendered in a disabled state. This change affects multiple components and ensures consistent behavior across the application.

### Addition of `disabled` attribute to service components:

* `web/app/components/services/cpu_slider_component.html.erb` and `web/app/components/services/cpu_slider_component.rb`: Added `disabled` attribute to the CPU slider component. [[1]](diffhunk://#diff-9cb16fb6e85c0b4f6c395f2849b5358eb6def5c2a7763814c1215c385ce6fb2cR4) [[2]](diffhunk://#diff-2fac1425ca6b9c08ee5a8c059b4eaa4434b522e819580f0cd459ba9afe762b00R5)
* `web/app/components/services/disk_slider_component.html.erb` and `web/app/components/services/disk_slider_component.rb`: Added `disabled` attribute to the disk slider component. [[1]](diffhunk://#diff-626859d5fd5994f7c4024851141a6592bb25dc85c23398224dfd822996a47e3aR4) [[2]](diffhunk://#diff-909efafaaa36645f3f26f019c2c6e9a39a149d5e6edd2d8e603dcfdef47afeeeR5)
* `web/app/components/services/environment_variable_component.html.erb` and `web/app/components/services/environment_variable_component.rb`: Added `disabled` attribute to the environment variable component. [[1]](diffhunk://#diff-5fe826a3efc562e49215b3d36882b8cb9ae93154c15215e09d7484c8163c3a77L3-R16) [[2]](diffhunk://#diff-1dc248cf45e09655182ab1e6d561af309342e5d38e81bf243a0accc3ef71fef9R5)
* `web/app/components/services/form_disk_component.html.erb` and `web/app/components/services/form_disk_component.rb`: Added `disabled` attribute to the form disk component. [[1]](diffhunk://#diff-f2e33ac4ad7f32fa8997563afdb180afb796f162c477054310d29335154f5285R15-R31) [[2]](diffhunk://#diff-0617661d7f4a2602b604c5306f64ba2e2b202cde4ed003b2d02a0353b3cc762fR5)
* `web/app/components/services/image_credentials_component.html.erb` and `web/app/components/services/image_credentials_component.rb`: Added `disabled` attribute to the image credentials component. [[1]](diffhunk://#diff-1331283050c4489aaff9c32d9d27e4d35d07717b722e666195fbd6d7858d6e25R15-R71) [[2]](diffhunk://#diff-d4cdeb057070eb3844c4ae48b22515cbcbb6a4d85bce24355e3e6aabc9d54d80R5)
* `web/app/components/services/memory_slider_component.html.erb` and `web/app/components/services/memory_slider_component.rb`: Added `disabled` attribute to the memory slider component. [[1]](diffhunk://#diff-cba72ec8054ffa0b9fb2b3c5ff040f6bf2151317f32386471cdf8689086493d1R4) [[2]](diffhunk://#diff-4f4bdb100626993cb176aa7fd89b815010112397316ef8406411a872b7845561R5)
* `web/app/components/services/port_component.html.erb` and `web/app/components/services/port_component.rb`: Added `disabled` attribute to the port component. [[1]](diffhunk://#diff-2a28cdd7f45e4e3f9d0a07449f507326efc4b7cea7f54fcae39731bc4bcb9f5aL4-R23) [[2]](diffhunk://#diff-cd8942c9c5226b362c0cccb737de69bc59f67a98bb47da8eeb36a9f523a54a15R5)
* `web/app/components/services/secret_component.html.erb` and `web/app/components/services/secret_component.rb`: Added `disabled` attribute to the secret component. [[1]](diffhunk://#diff-b4ec78388b6dce45dd17f1a69ac2c8fe4b4fbdd9ae6d8c74b517807579f80f24L3-R9) [[2]](diffhunk://#diff-224cfc0d35f81517c61b9b9c8007ceb71096fb29474c02bb32032ba214363777R5)
* [`web/app/components/services/service_form_component.html.erb`](diffhunk://#diff-4523a7a3b47f1c97cb15bc0aaac15699fb10b6eaf87e3e71e19cb8bdeb1902cbL4-R38): Added `disabled` attribute to various sections of the service form component. [[1]](diffhunk://#diff-4523a7a3b47f1c97cb15bc0aaac15699fb10b6eaf87e3e71e19cb8bdeb1902cbL4-R38) [[2]](diffhunk://#diff-4523a7a3b47f1c97cb15bc0aaac15699fb10b6eaf87e3e71e19cb8bdeb1902cbR48) [[3]](diffhunk://#diff-4523a7a3b47f1c97cb15bc0aaac15699fb10b6eaf87e3e71e19cb8bdeb1902cbR63) [[4]](diffhunk://#diff-4523a7a3b47f1c97cb15bc0aaac15699fb10b6eaf87e3e71e19cb8bdeb1902cbL72-R93)

### Removal of `enabled?` method:

* `web/app/components/services/element_component.html.erb` and `web/app/components/services/element_component.rb`: Removed the `enabled?` method and its associated conditional rendering logic. [[1]](diffhunk://#diff-4c73948c0f0940d3fde64cfe22ebb635018f39e184c16917687d2e4a56bb6d67L3-R3) [[2]](diffhunk://#diff-4c73948c0f0940d3fde64cfe22ebb635018f39e184c16917687d2e4a56bb6d67L30-L36) [[3]](diffhunk://#diff-f838449fe28088bb9ded1f30d13d14208bb609841dcd5a08000e3f7b4bd230d8L6-L9)