### PR TITLE
Fix consistent naming so that we check the previous version to see if…

### DIFF
--- a/web/app/components/dependencies/postgresql_component.html.erb
+++ b/web/app/components/dependencies/postgresql_component.html.erb
@@ -22,8 +22,8 @@
                                  :version,
                                  -> (v) { "Version #{v.human_visible_version}" },
                                  {},
-                                 disabled: disabled || update?,
-                                 class: ['text-sm w-7/12 p-2', { 'cursor-not-allowed bg-stone-100 opacity-90':  disabled || update? }] %>
+                                 disabled: enforces_version_consistency?,
+                                 class: ['text-sm w-7/12 p-2', { 'cursor-not-allowed bg-stone-100 opacity-90':  enforces_version_consistency? }] %>
     </div>
 
     <div class="flex items-center justify-between">
@@ -37,8 +37,8 @@
       <%= config_form.text_field :db_name,
                           'data-1p-ignore': true,
                           'data-lpignore': true,
-                          disabled: disabled || update?,
-                          class: ['text-sm w-7/12 p-2', { 'cursor-not-allowed bg-stone-100 opacity-90': disabled || update? }] %>
+                          disabled: enforces_version_consistency?,
+                          class: ['text-sm w-7/12 p-2', { 'cursor-not-allowed bg-stone-100 opacity-90': enforces_version_consistency? }] %>
     </div>
 
     <div class="flex items-center justify-between">
@@ -52,8 +52,8 @@
       <%= config_form.text_field :db_user,
                           'data-1p-ignore': true,
                           'data-lpignore': true,
-                          disabled: disabled || update?,
-                          class: ['text-sm w-7/12 p-2', { 'cursor-not-allowed bg-stone-100 opacity-90': disabled || update? }] %>
+                          disabled: enforces_version_consistency?,
+                          class: ['text-sm w-7/12 p-2', { 'cursor-not-allowed bg-stone-100 opacity-90': enforces_version_consistency? }] %>
     </div>
 
     <%= render UI::FormResourcesComponent.new(

--- a/web/app/components/dependencies/postgresql_component.rb
+++ b/web/app/components/dependencies/postgresql_component.rb
@@ -12,4 +12,17 @@ class Dependencies::PostgresqlComponent < DependenciesComponent
 
     "postgresql://#{username}:#{password}@#{host}/#{db_name}"
   end
+
+  def enforces_version_consistency?
+    # fields like name cannot change between versions, but can be updated if this is the first version and is unpublished
+    return true if disabled
+
+    previous_version = version.previous_version
+    return false if previous_version.nil?
+
+    # if previous version has a dependency with the same name, then we can't update
+    return true if previous_version.dependencies.any? { |d| d.info.name == dependency_instance.dependency.info.name }
+
+    false
+  end
 end

--- a/web/app/components/services/service_form_component.html.erb
+++ b/web/app/components/services/service_form_component.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: service_object, url:, method: form_method do |form| %>
   <%= form.hidden_field :service_id, value: service_object.service_id  %>
   <div class="flex flex-col gap-6">
-    <%= render UI::FormTextFieldComponent.new(title: 'Name', disabled: disabled || update?) do |component| %>
+    <%= render UI::FormTextFieldComponent.new(title: 'Name', disabled: enforces_version_consistency?) do |component| %>
       <%= component.with_label do %>
         Unique within the project. Must be lower case and contain only letters, numbers, and hyphens with no spaces. Cannot change in future versions.
       <% end %>
@@ -9,10 +9,10 @@
         <%= form.text_field :name,
                             placeholder: 'my-service',
                             required: true,
-                            disabled: disabled || update?,
+                            disabled: enforces_version_consistency?,
                             'data-1p-ignore': true,
                             'data-lpignore': true,
-                            class: ['text-sm w-full !p-0 border-0 focus:ring-0 bg-transparent', { 'cursor-not-allowed': disabled || update? }] %>
+                            class: ['text-sm w-full !p-0 border-0 focus:ring-0 bg-transparent', { 'cursor-not-allowed': enforces_version_consistency? }] %>
       <% end %>
     <% end %>
 

--- a/web/app/components/services/service_form_component.rb
+++ b/web/app/components/services/service_form_component.rb
@@ -23,4 +23,18 @@ class Services::ServiceFormComponent < ApplicationComponent
   def update?
     form_method == :patch
   end
+
+  def enforces_version_consistency?
+    # fields like name cannot change between versions
+    # It can be updated if this is the first version where it exists and is unpublished
+    return true if disabled
+
+    previous_version = version.previous_version
+    return false if previous_version.nil?
+
+    # if previous version has a service with the same name, then we can't update
+    return true if previous_version.services.any? { |s| s.name == service_object.name }
+
+    false
+  end
 end

--- a/web/app/views/dependencies/edit.html.erb
+++ b/web/app/views/dependencies/edit.html.erb
@@ -10,6 +10,7 @@
     dependency_instance: @dependency_instance,
     dependency_info: @dependency_info,
     form_method: :patch,
+    version: @version,
     disabled: @disabled
   ) %>
 

--- a/web/app/views/project/service/edit.html.erb
+++ b/web/app/views/project/service/edit.html.erb
@@ -17,7 +17,7 @@
     </div>
   </div>
 
-  <%= render Services::ServiceFormComponent.new(service_form_object: Service::Form.from_service(@service), form_method: :patch, disabled: @disabled) %>
+  <%= render Services::ServiceFormComponent.new(service_form_object: Service::Form.from_service(@service), form_method: :patch, version: @version, disabled: @disabled) %>
 
   <% unless @disabled %>
     <div class="flex flex-col gap-4 p-4 border-stone-300 border bg-white">


### PR DESCRIPTION
… there is a dpendency or service with the same name before deciding we can allow or disallow editing of name fields etc.

Have to have a think about how to support upgrading multi versions at once...