### PR TITLE
Fix disabled fields in service.

### DIFF
--- a/web/app/components/dependencies/postgresql_component.html.erb
+++ b/web/app/components/dependencies/postgresql_component.html.erb
@@ -17,13 +17,17 @@
       </span>
       </div>
 
-      <%= config_form.collection_select :app_version,
-                                 dependency_info.variants.sort_by(&:version).reverse,
-                                 :version,
-                                 -> (v) { "Version #{v.human_visible_version}" },
-                                 {},
-                                 disabled: enforces_version_consistency?,
-                                 class: ['text-sm w-7/12 p-2', { 'cursor-not-allowed bg-stone-100 opacity-90':  enforces_version_consistency? }] %>
+      <div class="<%= 'cursor-not-allowed' if enforces_version_consistency? %> w-7/12">
+        <%= config_form.collection_select :app_version,
+                                   dependency_info.variants.sort_by(&:version).reverse,
+                                   :version,
+                                   -> (v) { "Version #{v.human_visible_version}" },
+                                   {},
+                                   class: [
+                                     'text-sm w-full p-2',
+                                     { 'bg-stone-100 opacity-90 pointer-events-none':  enforces_version_consistency? }
+                                   ] %>
+      </div>
     </div>
 
     <div class="flex items-center justify-between">
@@ -37,8 +41,11 @@
       <%= config_form.text_field :db_name,
                           'data-1p-ignore': true,
                           'data-lpignore': true,
-                          disabled: enforces_version_consistency?,
-                          class: ['text-sm w-7/12 p-2', { 'cursor-not-allowed bg-stone-100 opacity-90': enforces_version_consistency? }] %>
+                          readonly: enforces_version_consistency?,
+                          class: [
+                            'text-sm w-7/12 p-2',
+                            { 'cursor-not-allowed bg-stone-100 opacity-90 focus:ring-0 focus:border-stone-500': enforces_version_consistency? }
+                          ] %>
     </div>
 
     <div class="flex items-center justify-between">
@@ -52,8 +59,8 @@
       <%= config_form.text_field :db_user,
                           'data-1p-ignore': true,
                           'data-lpignore': true,
-                          disabled: enforces_version_consistency?,
-                          class: ['text-sm w-7/12 p-2', { 'cursor-not-allowed bg-stone-100 opacity-90': enforces_version_consistency? }] %>
+                          readonly: enforces_version_consistency?,
+                          class: ['text-sm w-7/12 p-2', { 'cursor-not-allowed bg-stone-100 opacity-90 focus:ring-0 focus:border-stone-500': enforces_version_consistency? }] %>
     </div>
 
     <%= render UI::FormResourcesComponent.new(
@@ -61,7 +68,8 @@
       disk_options: Dependencies::PostgresqlForm::DISK_OPTIONS,
       cpu_options: Dependencies::PostgresqlForm::CPU_CORES_OPTIONS,
       memory_options: Dependencies::PostgresqlForm::MEMORY_OPTIONS,
-      disabled:
+      disabled:,
+      disabled_fields: enforces_version_consistency? ? %i[disk] : [] # disk is disabled if there is a previous version of the dependency
     ) %>
   <% end %>
 

--- a/web/app/components/dependencies/postgresql_component.rb
+++ b/web/app/components/dependencies/postgresql_component.rb
@@ -12,17 +12,4 @@ class Dependencies::PostgresqlComponent < DependenciesComponent
 
     "postgresql://#{username}:#{password}@#{host}/#{db_name}"
   end
-
-  def enforces_version_consistency?
-    # fields like name cannot change between versions, but can be updated if this is the first version and is unpublished
-    return true if disabled
-
-    previous_version = version.previous_version
-    return false if previous_version.nil?
-
-    # if previous version has a dependency with the same name, then we can't update
-    return true if previous_version.dependencies.any? { |d| d.info.name == dependency_instance.dependency.info.name }
-
-    false
-  end
 end

--- a/web/app/components/dependencies/redis_component.html.erb
+++ b/web/app/components/dependencies/redis_component.html.erb
@@ -33,7 +33,8 @@
       disk_options: Dependencies::RedisForm::DISK_OPTIONS,
       cpu_options: Dependencies::RedisForm::CPU_CORES_OPTIONS,
       memory_options: Dependencies::RedisForm::MEMORY_OPTIONS,
-      disabled:
+      disabled:,
+      disabled_fields: enforces_version_consistency? ? %i[disk] : [] # disk is disabled if there is a previous version of the dependency
     ) %>
   <% end %>
 

--- a/web/app/components/dependencies_component.rb
+++ b/web/app/components/dependencies_component.rb
@@ -23,4 +23,17 @@ class DependenciesComponent < ApplicationComponent
   def update?
     form_method == :patch
   end
+
+  def enforces_version_consistency?
+    # fields like name cannot change between versions, but can be updated if this is the first version and is unpublished
+    return true if disabled
+
+    previous_version = version.previous_version
+    return false if previous_version.nil?
+
+    # if previous version has a dependency with the same name, then we can't update
+    return true if previous_version.dependencies.any? { |d| d.info.name == dependency_info.name }
+
+    false
+  end
 end

--- a/web/app/components/services/disk_slider_component.html.erb
+++ b/web/app/components/services/disk_slider_component.html.erb
@@ -5,3 +5,4 @@
   labels: options_value.map { |m| number_to_human_size(m) },
   name: :disk_bytes
 ) %>
+<%= form.hidden_field :disk_bytes, value: form.object.disk_bytes if disabled %>

--- a/web/app/components/services/service_form_component.html.erb
+++ b/web/app/components/services/service_form_component.html.erb
@@ -9,10 +9,10 @@
         <%= form.text_field :name,
                             placeholder: 'my-service',
                             required: true,
-                            disabled: enforces_version_consistency?,
+                            readonly: enforces_version_consistency?,
                             'data-1p-ignore': true,
                             'data-lpignore': true,
-                            class: ['text-sm w-full !p-0 border-0 focus:ring-0 bg-transparent', { 'cursor-not-allowed': enforces_version_consistency? }] %>
+                            class: ['text-sm w-full !p-0 border-0 focus:ring-0 bg-transparent', { 'cursor-not-allowed focus:border-0': enforces_version_consistency? }] %>
       <% end %>
     <% end %>
 

--- a/web/app/components/ui/form_resources_component.html.erb
+++ b/web/app/components/ui/form_resources_component.html.erb
@@ -4,19 +4,19 @@
     <% if fields.include? :cpu %>
       <div class="flex items-start grow w-full gap-8">
         <span class="font-medium w-16">CPU</span>
-        <%= render Services::CPUSliderComponent.new(form:, options: cpu_options, disabled:) %>
+        <%= render Services::CPUSliderComponent.new(form:, options: cpu_options, disabled: cpu_disabled?) %>
       </div>
     <% end %>
     <% if fields.include? :memory %>
       <div class="flex items-start grow w-full gap-8">
         <span class="font-medium w-16">RAM</span>
-        <%= render Services::MemorySliderComponent.new(form:, options: memory_options, disabled:) %>
+        <%= render Services::MemorySliderComponent.new(form:, options: memory_options, disabled: memory_disabled?) %>
       </div>
     <% end %>
     <% if fields.include? :disk %>
       <div class="flex items-start grow w-full gap-8">
         <span class="font-medium w-16">Disk</span>
-        <%= render Services::DiskSliderComponent.new(form:, options: disk_options, disabled:) %>
+        <%= render Services::DiskSliderComponent.new(form:, options: disk_options, disabled: disk_disabled?) %>
       </div>
     <% end %>
   </div>

--- a/web/app/components/ui/form_resources_component.rb
+++ b/web/app/components/ui/form_resources_component.rb
@@ -7,4 +7,17 @@ class UI::FormResourcesComponent < ApplicationComponent
   attribute :cpu_options
   attribute :fields, default: %i[cpu memory disk]
   attribute :disabled, default: false
+  attribute :disabled_fields, default: []
+
+  def cpu_disabled?
+    disabled || disabled_fields.include?(:cpu)
+  end
+
+  def memory_disabled?
+    disabled || disabled_fields.include?(:memory)
+  end
+
+  def disk_disabled?
+    disabled || disabled_fields.include?(:disk)
+  end
 end

--- a/web/app/components/ui/form_text_field_component.html.erb
+++ b/web/app/components/ui/form_text_field_component.html.erb
@@ -11,7 +11,7 @@
     </span>
   </div>
 
-  <div class="text-sm w-7/12 text-input focus-within:ring-1 focus-within:ring-blue-500 focus-within:border-blue-500 <%= 'opacity-80 !bg-stone-100 !border-stone-400 cursor-not-allowed' if disabled %>">
+  <div class="text-sm w-7/12 text-input focus-within:ring-blue-500 focus-within:border-blue-500 <%= disabled ? 'opacity-80 !bg-stone-100 !border-stone-400 cursor-not-allowed' : 'focus-within:ring-1' %>">
     <%= field %>
   </div>
 </div>

--- a/web/app/form/dependencies/redis_form.rb
+++ b/web/app/form/dependencies/redis_form.rb
@@ -44,6 +44,7 @@ class Dependencies::RedisForm < Dependencies::Base
   end
 
   def update_dependency(dependency)
+    # TODO: ensure that we do not update fields you are not allowed to update here (disk version etc.)
     configs = dependency.configs.symbolize_keys.merge(configs_params.except(:db_password)) # don't update password
     dependency.update!(name:, version:, repo_url:, chart_name:, configs:)
   end

--- a/web/config/brakeman.ignore
+++ b/web/config/brakeman.ignore
@@ -37,13 +37,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "ad057d2a4e6d6c3006b0d2dee399aabfd320c4ee84e12696e1712d0efd9d6372",
+      "fingerprint": "d903548112aae474569a786763441bf0ee0582da3a3bc5db0c896d4e37ec6557",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/dependencies/edit.html.erb",
-      "line": 13,
+      "line": 14,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => current_team.dependencies.find(params[:id]).project_version.dependencies.find(params[:id]).info.form_component.new(:dependency_instance => current_team.dependencies.find(params[:id]).project_version.dependencies.find(params[:id]).info.form.from_dependency(current_team.dependencies.find(params[:id]).project_version.dependencies.find(params[:id])), :dependency_info => current_team.dependencies.find(params[:id]).project_version.dependencies.find(params[:id]).info, :form_method => :patch, :disabled => current_team.dependencies.find(params[:id]).project_version.published?), {})",
+      "code": "render(action => current_team.dependencies.find(params[:id]).project_version.dependencies.find(params[:id]).info.form_component.new(:dependency_instance => current_team.dependencies.find(params[:id]).project_version.dependencies.find(params[:id]).info.form.from_dependency(current_team.dependencies.find(params[:id]).project_version.dependencies.find(params[:id])), :dependency_info => current_team.dependencies.find(params[:id]).project_version.dependencies.find(params[:id]).info, :form_method => :patch, :version => current_team.dependencies.find(params[:id]).project_version, :disabled => current_team.dependencies.find(params[:id]).project_version.published?), {})",
       "render_path": [
         {
           "type": "controller",


### PR DESCRIPTION
Updating a service on a new version would break when the service existed on a previous version as the validation would fail. Fixed by making the field readonly instead. TODO: validation on server side.

Also disabled disk on dependencies when it exists in a prior version.