### PR TITLE
Add a comparisons module which allows you to compare two versions.

### DIFF
--- a/web/app/lib/comparisons.rb
+++ b/web/app/lib/comparisons.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Comparisons
+  # Represents a change in a field of an object.
+  #
+  # @!attribute [r] field
+  #   @return [String] the name of the field that changed
+  # @!attribute [r] old_value
+  #   @return [Object] the old value of the field
+  # @!attribute [r] new_value
+  #   @return [Object] the new value of the field
+  Change = Struct.new(:field, :old_value, :new_value, keyword_init: true)
+
+  # Represents a comparison of an object (service or dependency) between two versions.
+  #
+  # @!attribute [r] name
+  #   @return [String] the name of the object being compared
+  # @!attribute [r] type
+  #   @return [Symbol] the type of the object (:service or :dependency)
+  # @!attribute [r] status
+  #   @return [Symbol] the status of the object (:added, :modified, or :removed)
+  # @!attribute [r] changes
+  #   @return [Array<Change>] the list of changes for the object
+  ObjectComparison = Struct.new(
+    :name,
+    :type,
+    :status,
+    :changes,
+    keyword_init: true
+  ) do
+    # Checks if the object is a dependency.
+    # @return [Boolean] true if the object is a dependency, false otherwise
+    def dependency?
+      type == :dependency
+    end
+
+    # Checks if the object is a service.
+    # @return [Boolean] true if the object is a service, false otherwise
+    def service?
+      type == :service
+    end
+
+    # Checks if the object is modified.
+    # @return [Boolean] true if the object is modified, false otherwise
+    def modified?
+      status == :modified
+    end
+
+    # Checks if the object is added.
+    # @return [Boolean] true if the object is added, false otherwise
+    def added?
+      status == :added
+    end
+
+    # Checks if the object is removed.
+    # @return [Boolean] true if the object is removed, false otherwise
+    def removed?
+      status == :removed
+    end
+  end
+end

--- a/web/app/lib/comparisons/common.rb
+++ b/web/app/lib/comparisons/common.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Comparisons::Common
+  class << self
+    # Compares attributes between two objects and returns a list of changes.
+    #
+    # @param attrs_hash [Hash] A hash where keys are attribute names and values are display names.
+    # @param base [Object] The base object to compare.
+    # @param incoming [Object] The incoming object to compare.
+    # @return [Array<Comparisons::Change>] An array of changes, each represented by a Comparisons::Change object.
+    def simple_comparisons(attrs_hash, base:, incoming:)
+      attrs_hash.map do |attr, display_name|
+        simple_compare(attr, display_name, base, incoming)
+      end.compact
+    end
+
+    # Compares arrays of hashes and returns a list of changes.
+    #
+    # @param key_field [String] The key field to identify unique objects in the arrays.
+    # @param value_field [String] The value field to compare between the objects.
+    # @param base [Array<Hash>] The base array of hashes to compare.
+    # @param incoming [Array<Hash>] The incoming array of hashes to compare.
+    # @param display_field [String] The display name for the field being compared.
+    # @return [Array<Comparisons::Change>] An array of changes, each represented by a Comparisons::Change object.
+    def array_hash_comparisons(key_field:, value_field:, base:, incoming:, display_field:)
+      (base + incoming)
+        .map { |obj| obj[key_field] }
+        .uniq
+        .map do |key|
+        old_value = base.find { |obj| obj[key_field] == key }&.dig(value_field)
+        new_value = incoming.find { |obj| obj[key_field] == key }&.dig(value_field)
+        next if old_value == new_value
+
+        Comparisons::Change.new(field: "#{display_field} #{key}", old_value:, new_value:)
+      end.compact
+    end
+
+    # Compares arrays and returns a list of changes.
+    #
+    # @param base [Array] The base array to compare.
+    # @param incoming [Array] The incoming array to compare.
+    # @param display_field [String] The display name for the field being compared.
+    # @return [Array<Comparisons::Change>] An array of changes, each represented by a Comparisons::Change object.
+    def array_comparisons(base:, incoming:, display_field:)
+      (base + incoming)
+        .uniq
+        .map do |value|
+        old_value = base.include?(value) ? value : nil
+        new_value = incoming.include?(value) ? value : nil
+        next if old_value.present? && new_value.present?
+
+        Comparisons::Change.new(field: display_field, old_value:, new_value:)
+      end.compact
+    end
+
+    private
+
+    def simple_compare(attribute, display_name, base, incoming)
+      old_value = base.public_send(attribute)
+      new_value = incoming.public_send(attribute)
+
+      return nil if old_value == new_value
+
+      Comparisons::Change.new(field: display_name, old_value:, new_value:)
+    end
+  end
+end

--- a/web/app/lib/comparisons/dependency.rb
+++ b/web/app/lib/comparisons/dependency.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Comparisons::Dependency
+  def self.compare(base, incoming)
+    simple_compares = {
+      version: "Version",
+      repo_url: "Repo URL"
+    }
+    changes = Comparisons::Common.simple_comparisons(simple_compares, base:, incoming:)
+
+    # TODO: add new modules in data.rb to compare the configs fields for each dependency
+    config_changes = base.configs.map do |field, old_value|
+      new_value = incoming.configs[field]
+      next if new_value == old_value
+
+      Comparisons::Change.new(field:, old_value:, new_value:)
+    end
+
+    changes + config_changes.compact
+  end
+end

--- a/web/app/lib/comparisons/service.rb
+++ b/web/app/lib/comparisons/service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Comparisons::Service
+  def self.compare(base, incoming)
+    simple_compares = {
+      image: "Image",
+      cpu_cores: "CPU Cores",
+      memory_bytes: "Memory",
+      predeploy_command: "Predeploy Command",
+      ingress_port: "Ingress Port",
+      image_username: "Image Username",
+      image_password: "Image Password"
+    }
+    changes = Comparisons::Common.simple_comparisons(simple_compares, base:, incoming:)
+
+    env_var_changes = Comparisons::Common.array_hash_comparisons(
+      key_field: "name",
+      value_field: "value",
+      base: base.environment_variables,
+      incoming: incoming.environment_variables,
+      display_field: "Environment Variable"
+    )
+
+    secrets_changes = Comparisons::Common.array_comparisons(
+      base: base.secrets.map(&:environment_key),
+      incoming: incoming.secrets.map(&:environment_key),
+      display_field: "Secret"
+    )
+
+    ports_changes = Comparisons::Common.array_comparisons(
+      base: base.ports,
+      incoming: incoming.ports,
+      display_field: "Port"
+    )
+
+    changes + env_var_changes + secrets_changes + ports_changes
+  end
+end

--- a/web/app/lib/comparisons/version.rb
+++ b/web/app/lib/comparisons/version.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Comparisons::Version
+  VersionComparison = Struct.new(
+    :base_version,
+    :incoming_version,
+    :comparisons,
+    keyword_init: true
+  ) do
+    class << self
+      def from(base_version, incoming_version)
+        comparisons = [
+          compare_objects(base_version.services, incoming_version.services, type: :service),
+          compare_objects(base_version.dependencies, incoming_version.dependencies, type: :dependency)
+        ].flatten.compact
+
+        new(base_version:, incoming_version:, comparisons:)
+      end
+
+      private
+
+      def compare_objects(base_objects, incoming_objects, type:)
+        base_objects = base_objects.index_by(&:name)
+        incoming_objects = incoming_objects.index_by(&:name)
+        all_service_names = (base_objects.keys + incoming_objects.keys).uniq
+
+        all_service_names.map do |name|
+          base_object = base_objects[name]
+          incoming_object = incoming_objects[name]
+
+          # default to modified, if not added or removed and not actually modified. we exit early.
+          status = :modified
+          changes = []
+
+          status = :added if base_object.nil?
+          status = :removed if incoming_object.nil?
+          changes = base_object.compare(incoming_object) if status == :modified
+          next if changes.empty? && status == :modified
+
+          Comparisons::ObjectComparison.new(name:, type:, status:, changes:)
+        end
+      end
+    end
+
+    def has_changes?
+      comparisons.any?
+    end
+  end
+end

--- a/web/app/models/dependency.rb
+++ b/web/app/models/dependency.rb
@@ -26,5 +26,9 @@ class Dependency < ApplicationRecord
     "v#{info.human_visible_version(configs["app_version"])}" if configs["app_version"].present?
   end
 
+  def compare(other)
+    Comparisons::Dependency.compare(self, other)
+  end
+
   delegate :human_visible_name, :icon, :form_component, to: :info
 end

--- a/web/app/models/project_service.rb
+++ b/web/app/models/project_service.rb
@@ -68,6 +68,10 @@ class ProjectService < ApplicationRecord
     DockerImageUrlParser.new(image).to_s(with_tag: false)
   end
 
+  def compare(other)
+    Comparisons::Service.compare(self, other)
+  end
+
   private
 
   def set_pvc_name

--- a/web/app/models/project_version.rb
+++ b/web/app/models/project_version.rb
@@ -65,4 +65,12 @@ class ProjectVersion < ApplicationRecord
   def deployable?
     services.any?
   end
+
+  # Compares the current project version with an incoming version.
+  #
+  # @param incoming_version [ProjectVersion] The version to compare against.
+  # @return [Comparisons::Version::VersionComparison] The comparison result.
+  def compare(incoming_version)
+    Comparisons::Version::VersionComparison.from(self, incoming_version)
+  end
 end

--- a/web/spec/factories/project_service_factory.rb
+++ b/web/spec/factories/project_service_factory.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     pvc_size_bytes { nil }
     pvc_mount_path { nil }
     pvc_name { 'standard-pvc-name' }
+    ports { [ 80 ] }
 
     transient do
       team { nil }

--- a/web/spec/lib/comparisons/version_comparator_spec.rb
+++ b/web/spec/lib/comparisons/version_comparator_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Comparisons::Version do
+  let(:project) { create(:project) }
+  let(:base_version) { create(:project_version, project:) }
+  let(:incoming_version) { create(:project_version, project:) }
+
+  describe 'VersionComparison' do
+    describe '.from' do
+      context 'with no changes' do
+        let(:base_service) { create(:project_service, project_version: base_version, name: 'web') }
+        let(:incoming_service) do
+          create(:project_service,
+                 project_version: incoming_version,
+                 name: 'web',
+                 image: base_service.image,
+                 environment_variables: base_service.environment_variables)
+        end
+
+        let(:base_dependency) { create(:dependency, project_version: base_version, name: 'redis') }
+        let(:incoming_dependency) do
+          create(:dependency,
+                 project_version: incoming_version,
+                 name: 'redis',
+                 configs: base_dependency.configs)
+        end
+
+        before do
+          base_service && incoming_service
+          base_dependency && incoming_dependency
+        end
+
+        it 'returns empty comparisons when no changes exist' do
+          comparison = described_class::VersionComparison.from(base_version, incoming_version)
+          expect(comparison.has_changes?).to be false
+          expect(comparison.comparisons).to be_empty
+        end
+      end
+
+      context 'with service changes' do
+        context 'when a service is added' do
+          let!(:incoming_service) { create(:project_service, project_version: incoming_version, name: 'new-service') }
+
+          it 'detects added service' do
+            comparison = described_class::VersionComparison.from(base_version, incoming_version)
+            expect(comparison.has_changes?).to be true
+
+            added = comparison.comparisons.find { |c| c.name == 'new-service' }
+            expect(added).to have_attributes(
+                               type: :service,
+                               status: :added,
+                               changes: be_empty
+                             )
+          end
+        end
+
+        context 'when a service is removed' do
+          let!(:base_service) do
+            create(:project_service,
+                   project_version: base_version,
+                   name: 'removed-service')
+          end
+
+          it 'detects removed service' do
+            comparison = described_class::VersionComparison.from(base_version, incoming_version)
+            expect(comparison.has_changes?).to be true
+
+            removed = comparison.comparisons.find { |c| c.name == 'removed-service' }
+            expect(removed).to have_attributes(
+                                 type: :service,
+                                 status: :removed,
+                                 changes: be_empty
+                               )
+          end
+        end
+
+        context 'when a service is modified' do
+          let(:base_service) { create(:project_service, project_version: base_version, name: 'web', image: 'nginx:1.19', environment_variables: [ { 'name' => 'ENV', 'value' => 'prod' } ]) }
+
+          let(:incoming_service) do
+            create(:project_service,
+                   project_version: incoming_version,
+                   name: 'web',
+                   image: 'nginx:1.20',
+                   environment_variables: [ { 'name' => 'ENV', 'value' => 'staging' } ])
+          end
+
+          before do
+            base_service && incoming_service
+          end
+
+          it 'detects modified service with correct changes' do
+            comparison = described_class::VersionComparison.from(base_version, incoming_version)
+            expect(comparison.has_changes?).to be true
+
+            modified = comparison.comparisons.find { |c| c.name == 'web' }
+            expect(modified).to have_attributes(
+                                  type: :service,
+                                  status: :modified
+                                )
+
+            changes = modified.changes
+            expect(changes).to contain_exactly(
+                                 have_attributes(
+                                   field: 'Image',
+                                   old_value: 'nginx:1.19',
+                                   new_value: 'nginx:1.20'
+                                 ),
+                                 have_attributes(
+                                   field: 'Environment Variable ENV',
+                                   old_value: 'prod',
+                                   new_value: 'staging'
+                                 )
+                               )
+          end
+        end
+      end
+
+      context 'with dependency changes' do
+        context 'when a dependency is added' do
+          let!(:incoming_dependency) { create(:dependency, project_version: incoming_version, name: 'redis') }
+
+          it 'detects added dependency' do
+            comparison = described_class::VersionComparison.from(base_version, incoming_version)
+            expect(comparison.has_changes?).to be true
+
+            added = comparison.comparisons.find { |c| c.name == 'redis' }
+            expect(added).to have_attributes(
+                               type: :dependency,
+                               status: :added,
+                               changes: be_empty
+                             )
+          end
+        end
+
+        context 'when a dependency is removed' do
+          let!(:base_dependency) { create(:dependency, project_version: base_version, name: 'redis') }
+
+          it 'detects removed dependency' do
+            comparison = described_class::VersionComparison.from(base_version, incoming_version)
+            expect(comparison.has_changes?).to be true
+
+            removed = comparison.comparisons.find { |c| c.name == 'redis' }
+            expect(removed).to have_attributes(
+                                 type: :dependency,
+                                 status: :removed,
+                                 changes: be_empty
+                               )
+          end
+        end
+
+        context 'when a dependency is modified' do
+          let(:base_dependency) do
+            create(:dependency,
+                   project_version: base_version,
+                   name: 'redis',
+                   configs: { 'version' => '6.0' })
+          end
+
+          let(:incoming_dependency) do
+            create(:dependency,
+                   project_version: incoming_version,
+                   name: 'redis',
+                   configs: { 'version' => '7.0' })
+          end
+
+          before do
+            base_dependency && incoming_dependency
+          end
+
+          it 'detects modified dependency with correct changes' do
+            comparison = described_class::VersionComparison.from(base_version, incoming_version)
+            expect(comparison.has_changes?).to be true
+
+            modified = comparison.comparisons.find { |c| c.name == 'redis' }
+            expect(modified).to have_attributes(
+                                  type: :dependency,
+                                  status: :modified
+                                )
+
+            expect(modified.changes).to contain_exactly(
+                                          have_attributes(
+                                            field: 'version',
+                                            old_value: '6.0',
+                                            new_value: '7.0'
+                                          )
+                                        )
+          end
+        end
+      end
+    end
+
+    describe 'ObjectComparison' do
+      subject(:comparison) do
+        Comparisons::ObjectComparison.new(
+          name: 'test',
+          type: type,
+          status: status,
+          changes: []
+        )
+      end
+
+      context 'with service type' do
+        let(:type) { :service }
+        let(:status) { :modified }
+
+        it { is_expected.to be_service }
+        it { is_expected.not_to be_dependency }
+      end
+
+      context 'with dependency type' do
+        let(:type) { :dependency }
+        let(:status) { :modified }
+
+        it { is_expected.to be_dependency }
+        it { is_expected.not_to be_service }
+      end
+
+      context 'with different statuses' do
+        let(:type) { :service }
+
+        context 'when added' do
+          let(:status) { :added }
+          it { is_expected.to be_added }
+          it { is_expected.not_to be_modified }
+          it { is_expected.not_to be_removed }
+        end
+
+        context 'when removed' do
+          let(:status) { :removed }
+          it { is_expected.to be_removed }
+          it { is_expected.not_to be_modified }
+          it { is_expected.not_to be_added }
+        end
+
+        context 'when modified' do
+          let(:status) { :modified }
+          it { is_expected.to be_modified }
+          it { is_expected.not_to be_added }
+          it { is_expected.not_to be_removed }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add model methods to project version service and dependency to compare likewise also.

This pull request introduces a comprehensive comparison framework for services and dependencies, along with their respective versions. The changes include new modules and methods for comparing objects, handling changes, and generating comparison results.

### New Comparison Framework:

* [`web/app/lib/comparisons.rb`](diffhunk://#diff-87ab50c44128a93274db6827f59757af5f2bb2e379575e3bdfae338d58355d8eR1-R61): Introduced `Change` and `ObjectComparison` structs to represent changes and comparisons of objects.
* [`web/app/lib/comparisons/common.rb`](diffhunk://#diff-e44572faa8dc91abb4975e65f31253e4cb6b9186830ce82761705c119bdb207bR1-R67): Added common comparison methods for attributes, arrays of hashes, and arrays.
* [`web/app/lib/comparisons/dependency.rb`](diffhunk://#diff-9392a42ad315e5772adf5feec0aea372aeda0d53c5c48a480fc9cff84ce0fb00R1-R21): Implemented comparison logic for dependencies, including version and repo URL comparisons.
* [`web/app/lib/comparisons/service.rb`](diffhunk://#diff-d781eefa6a6c46d87ec5e0b971c00ef9d55594919516672fe997a085341be5a0R1-R38): Implemented comparison logic for services, including image, CPU, memory, and environment variables comparisons.
* [`web/app/lib/comparisons/version.rb`](diffhunk://#diff-8324051322d787971bc7da77cda86eda561972faeb87994ee4cff8ad19955cf5R1-R49): Added `VersionComparison` struct to handle version comparisons, including services and dependencies.

### Model Enhancements:

* [`web/app/models/dependency.rb`](diffhunk://#diff-d31b0d478c0d058cf4ef828d832aec9cfde204d5b54bd00b6e40c43912cd68e7R29-R32): Added `compare` method to compare dependencies using the new framework.
* [`web/app/models/project_service.rb`](diffhunk://#diff-cff02ba1fd81063b96e21b554616d65294826c1c220f8f0ed6010cd2e708beffR71-R74): Added `compare` method to compare project services using the new framework.
* [`web/app/models/project_version.rb`](diffhunk://#diff-9c674206a1b5e59275a899c930b483c1fa5f36fc349a75d18c3877666d11677cR68-R75): Added `compare` method to compare project versions, utilizing the `VersionComparison` struct.

### Test Coverage:

* [`web/spec/lib/comparisons/version_comparator_spec.rb`](diffhunk://#diff-6ff40552611a744dd24ab59f8e943830d5a87c99f23f12cc6bbd0200af448b33R1-R247): Added tests for the `VersionComparison` and `ObjectComparison` structs, covering scenarios for added, removed, and modified services and dependencies.
* [`web/spec/models/project_version_spec.rb`](diffhunk://#diff-38e77aeb7652118c8f594e5ff806315485b2463a005a097eae170f4403a772e2R123-R156): Added tests for the `compare` method in `ProjectVersion` model to ensure accurate detection of changes.