### PR TITLE
Show uptime status bars for an agent instance.

### DIFF
--- a/web/app/components/agent_instance/status_component.html.erb
+++ b/web/app/components/agent_instance/status_component.html.erb
@@ -19,6 +19,8 @@
   </div>
   <div class="bg-stone-100 p-4 flex flex-col gap-4" data-ui--accordion-target="panel">
 
+    <%= render Containers::ContainerStatusComponent.new(containers: [agent_instance]) %>
+
     <div class="flex flex-col gap-2">
       <% if subscriber.project.project_versions.published.count > 1 %>
         <div class="flex flex-col gap-1">
@@ -38,7 +40,7 @@
                 class: 'p-1 pl-2 pr-8 min-w-32'
             %>
             <%= form.button :submit,
-                            class: 'bg-green-600 p-1 font-medium text-white px-2 border border-green-600 hover:shadow duration-200',
+                            class: 'bg-white p-1 px-2 border border-stone-500 hover:shadow hover:bg-stone-50 duration-200',
                             disabled: !subscriber.eligible_for_new_action?,
                             data: { turbo_confirm: 'Are you sure you want to deploy a new version?' } do %>
               Deploy ->

--- a/web/app/components/containers/container_status_component.html.erb
+++ b/web/app/components/containers/container_status_component.html.erb
@@ -1,18 +1,7 @@
-<div class="w-full whitespace-nowrap px-6 pb-8 pt-6 flex flex-col gap-2 w-full" data-controller="hide-show">
-  <div class="flex items-center justify-between gap-2" data-action="click->hide-show#toggle">
-    <div class="flex items-center gap-1">
-      <span class="text-stone-100 font-semibold"><%= name %></span>
-      <span class="text-stone-400 text-sm"><%= containers.count %> instances</span>
-      <%= heroicon 'chevron-down', class: 'size-5 text-stone-400 cursor-pointer' %>
-    </div>
-    <span class="<%= text_classes(group_status.current_status) %>"><%= status_text(group_status.current_status) %></span>
-  </div>
-
-  <%= render Containers::GroupStatusComponent.new(group_status:) %>
-
-  <div class="flex flex-col gap-2 hidden" data-hide-show-target="content">
+<div class="w-full whitespace-nowrap p-2 flex flex-col gap-2 w-full">
+  <div class="flex flex-col gap-2">
     <% group_status.constituent_stats.zip(containers).each do |container_stats, container| %>
-      <%= render Containers::IndividualContainerStatusComponent.new(status_bars: container_stats.values.reverse, name: container_stats.values.first[:lifecycle_id], container: ) %>
+      <%= render Containers::IndividualContainerStatusComponent.new(status_bars: container_stats.values.reverse, container:) %>
     <% end %>
   </div>
 </div>

--- a/web/app/components/containers/individual_container_status_component.html.erb
+++ b/web/app/components/containers/individual_container_status_component.html.erb
@@ -1,14 +1,7 @@
 <div class="flex flex-col gap-2 mt-1">
-  <% if name.present? %>
-    <div class="flex items-center justify-between gap-2">
-      <span class="text-stone-100 font-semibold mt-1"><%= name %></span>
-      <span class="<%= text_classes(current_status) %>"><%= status_text(current_status) %></span>
-    </div>
-
-  <% end %>
-  <div class="flex justify-center items-center gap-1.5 h-10 grow">
+  <div class="flex justify-center items-center gap-[5px] h-10 grow">
     <% status_bars.each do |status_bar| %>
-      <div class="relative group max-w-2 min-w-1 w-full h-full <%= bg_classes(status_bar[:status]) %>">
+      <div class="relative group max-w-2 min-w-[3px] w-full h-full <%= bg_classes(status_bar[:status]) %>">
         <div class="absolute flex flex-col gap-0.5 top-10 left-0 border border-stone-400 rounded-md bg-stone-800 text-stone-100 text-xs rounded px-2 py-1 whitespace-nowrap z-40 opacity-0 group-hover:opacity-100">
           <%= status_bar[:date].strftime('%B %d, %Y') %>
           <div class="flex justify-between items-baseline gap-2">

--- a/web/app/components/containers/individual_container_status_component.rb
+++ b/web/app/components/containers/individual_container_status_component.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Containers::IndividualContainerStatusComponent < ApplicationComponent
-  attribute :name
   attribute :status_bars
   attribute :container
 
@@ -9,7 +8,7 @@ class Containers::IndividualContainerStatusComponent < ApplicationComponent
 
   def current_status
     return @current_status if defined?(@current_status)
-    return @current_status = :offline if container&.unhealthy?
+    return @current_status = :offline unless container&.healthy?
 
     @current_status = :online
   end
@@ -27,7 +26,9 @@ class Containers::IndividualContainerStatusComponent < ApplicationComponent
     with_data_bars = status_bars.filter { |bar| bar[:status] != :no_data }
     return 0 if with_data_bars.empty?
 
-    with_data_bars.sum { |bar| bar[:uptime_percentage] } / with_data_bars.size
+    percentage = with_data_bars.sum { |bar| bar[:uptime_percentage] } / with_data_bars.size
+
+    percentage.round(1)
   end
 
   def bg_classes(status)

--- a/web/app/lib/container_status/heartbeat_stats.rb
+++ b/web/app/lib/container_status/heartbeat_stats.rb
@@ -45,6 +45,7 @@ class ContainerStatus::HeartbeatStats
     result.each do |_, day_data|
       next if day_data[:status] == :no_data
       day_data[:status] = determine_status(day_data[:downtime_minutes])
+      day_data[:uptime_percentage] = calculate_percentage(day_data[:uptime_minutes], day_data[:downtime_minutes])
     end
   end
 
@@ -105,7 +106,7 @@ class ContainerStatus::HeartbeatStats
     total = uptime + downtime
     return 0 if total.zero?
 
-    (uptime / total.to_f * 100).round(2)
+    (uptime / total.to_f * 100).round(1)
   end
 
   def calculate_first_day_uptime(first_heartbeat, downtime)


### PR DESCRIPTION
For the moment this will only show data from the most recent instance (helm release) and nothing else.

We will soon make a change to make the agent stateful and will pass back a stateful idea for each deployment space which we can use here.

Also fixed some issues with status bars (old code brought back to life). Need to do a bit of refactoring on these components as they were built with different assumptions.