### PR TITLE
Add session id and udpated lifecycleId to agent.

### DIFF
--- a/agent/agent/agent.go
+++ b/agent/agent/agent.go
@@ -133,31 +133,3 @@ func applyChart(ctx context.Context, action *service_pb.ApplyChartRequest) error
 
 	return nil
 }
-
-// func getOrCreateLifecycleID(filePath string) string {
-// 	const (
-// 		DirectoryPermissions = 0755 // Owner can read/write/execute, others can read/execute
-// 		FilePermissions      = 0644 // Owner can read/write, others can read only
-// 	)
-    
-//     // Try to read existing ID
-//     content, err := os.ReadFile(filePath)
-//     if err == nil && len(content) > 0 {
-//         return strings.TrimSpace(string(content))
-//     }
-    
-//     newID := uuid.New().String()
-    
-//     // Ensure directory exists
-//     if err := os.MkdirAll(filepath.Dir(filePath), DirectoryPermissions); err != nil {
-//         log.Printf("Failed to create directory: %v", err)
-//         return newID
-//     }
-    
-//     // Write new ID to file
-//     if err := os.WriteFile(filePath, []byte(newID), FilePermissions); err != nil {
-//         log.Printf("Failed to write lifecycle ID: %v", err)
-//     }
-    
-//     return newID
-// }

--- a/agent/agent/agent.go
+++ b/agent/agent/agent.go
@@ -4,12 +4,10 @@ import (
 	"agent/backend"
 	"agent/cluster"
 	"agent/generated/service_pb"
+	"agent/lifecycleid"
 	"agent/periodic"
 	"context"
 	"log"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -87,7 +85,7 @@ func (a *Agent) apply(ctx context.Context) {
 }
 
 func NewAgent(cfg AgentConfig) (*Agent, error) {
-	lifecycleID := getOrCreateLifecycleID(cfg.LifecycleIDFilePath)
+	lifecycleID := lifecycleid.NewLifecycleIDGenerator(cfg.LifecycleIDFilePath).Generate()
 	sessionID := uuid.New().String()
 
 	log.Printf("Creating client with backend address %s, and token: %s", cfg.BackendAddr, cfg.BearerToken)
@@ -136,30 +134,30 @@ func applyChart(ctx context.Context, action *service_pb.ApplyChartRequest) error
 	return nil
 }
 
-func getOrCreateLifecycleID(filePath string) string {
-	const (
-		DirectoryPermissions = 0755 // Owner can read/write/execute, others can read/execute
-		FilePermissions      = 0644 // Owner can read/write, others can read only
-	)
+// func getOrCreateLifecycleID(filePath string) string {
+// 	const (
+// 		DirectoryPermissions = 0755 // Owner can read/write/execute, others can read/execute
+// 		FilePermissions      = 0644 // Owner can read/write, others can read only
+// 	)
     
-    // Try to read existing ID
-    content, err := os.ReadFile(filePath)
-    if err == nil && len(content) > 0 {
-        return strings.TrimSpace(string(content))
-    }
+//     // Try to read existing ID
+//     content, err := os.ReadFile(filePath)
+//     if err == nil && len(content) > 0 {
+//         return strings.TrimSpace(string(content))
+//     }
     
-    newID := uuid.New().String()
+//     newID := uuid.New().String()
     
-    // Ensure directory exists
-    if err := os.MkdirAll(filepath.Dir(filePath), DirectoryPermissions); err != nil {
-        log.Printf("Failed to create directory: %v", err)
-        return newID
-    }
+//     // Ensure directory exists
+//     if err := os.MkdirAll(filepath.Dir(filePath), DirectoryPermissions); err != nil {
+//         log.Printf("Failed to create directory: %v", err)
+//         return newID
+//     }
     
-    // Write new ID to file
-    if err := os.WriteFile(filePath, []byte(newID), FilePermissions); err != nil {
-        log.Printf("Failed to write lifecycle ID: %v", err)
-    }
+//     // Write new ID to file
+//     if err := os.WriteFile(filePath, []byte(newID), FilePermissions); err != nil {
+//         log.Printf("Failed to write lifecycle ID: %v", err)
+//     }
     
-    return newID
-}
+//     return newID
+// }

--- a/agent/backend/client.go
+++ b/agent/backend/client.go
@@ -13,6 +13,7 @@ import (
 
 type Identity struct {
 	LifecycleID string
+	SessionID   string
 	Name        string
 	VersionID   string
 }
@@ -43,6 +44,7 @@ func (c *Client) Apply(ctx context.Context) (*service_pb.Action, error) {
 	resp, err := c.client.Apply(ctx, &service_pb.ApplyRequest{
 		Identity: &service_pb.Identity{
 			LifecycleId: c.identity.LifecycleID,
+			SessionId:   c.identity.SessionID,
 			Name:        c.identity.Name,
 			VersionId:   c.identity.VersionID,
 		},
@@ -58,6 +60,7 @@ func (c *Client) Heartbeat(ctx context.Context) error {
 	_, err := c.client.Heartbeat(ctx, &service_pb.HeartbeatRequest{
 		Identity: &service_pb.Identity{
 			LifecycleId: c.identity.LifecycleID,
+			SessionId:   c.identity.SessionID,
 			Name:        c.identity.Name,
 			VersionId:   c.identity.VersionID,
 		},

--- a/agent/backend/client_test.go
+++ b/agent/backend/client_test.go
@@ -23,6 +23,7 @@ func TestNewClient(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := NewClient(tt.addr, tt.bearerToken, Identity{
 				LifecycleID: "test-lifecycle-id",
+				SessionID:  "test-session-id",
 				Name:        "test-name",
 			})
 			if !tt.wantErr && err != nil {

--- a/agent/lifecycleid/lifecycleid_generator.go
+++ b/agent/lifecycleid/lifecycleid_generator.go
@@ -1,0 +1,51 @@
+package lifecycleid
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+type LifecycleIDGenerator struct {
+	LifecycleIDFilePath string
+}
+
+func NewLifecycleIDGenerator(lifecycleIDFilePath string) *LifecycleIDGenerator {
+	return &LifecycleIDGenerator{
+		LifecycleIDFilePath: lifecycleIDFilePath,
+	}
+}
+
+func (l *LifecycleIDGenerator) Generate() string {
+	const (
+		DirectoryPermissions = 0755 // Owner can read/write/execute, others can read/execute
+		FilePermissions      = 0644 // Owner can read/write, others can read only
+	)
+
+	filePath := l.LifecycleIDFilePath
+    
+    // Try to read existing ID
+    content, err := os.ReadFile(filePath)
+    if err == nil && len(content) > 0 {
+		log.Printf("Found existing lifecycle ID: %s", string(content))
+        return strings.TrimSpace(string(content))
+    }
+    
+    newID := uuid.New().String()
+    
+    // Ensure directory exists
+    if err := os.MkdirAll(filepath.Dir(filePath), DirectoryPermissions); err != nil {
+        log.Printf("Failed to create directory: %v", err)
+        return newID
+    }
+    
+    // Write new ID to file
+    if err := os.WriteFile(filePath, []byte(newID), FilePermissions); err != nil {
+        log.Printf("Failed to write lifecycle ID: %v", err)
+    }
+    
+    return newID
+}

--- a/agent/lifecycleid/lifecycleid_generator_test.go
+++ b/agent/lifecycleid/lifecycleid_generator_test.go
@@ -1,0 +1,50 @@
+package lifecycleid
+
+import (
+    "os"
+    "path/filepath"
+    "testing"
+)
+
+func TestLifecycleIDGenerator_Generate(t *testing.T) {
+    // Create temp directory for tests
+    tmpDir := t.TempDir()
+    filePath := filepath.Join(tmpDir, "lifecycle.id")
+
+    t.Run("generates new ID when file doesn't exist", func(t *testing.T) {
+        generator := NewLifecycleIDGenerator(filePath)
+        id1 := generator.Generate()
+        if id1 == "" {
+            t.Error("Generated ID should not be empty")
+        }
+    })
+
+    t.Run("returns same ID when file exists", func(t *testing.T) {
+        generator := NewLifecycleIDGenerator(filePath)
+        id1 := generator.Generate()
+        id2 := generator.Generate()
+        if id1 != id2 {
+            t.Errorf("Expected same ID on second call, got %s != %s", id1, id2)
+        }
+    })
+
+    t.Run("handles invalid file path", func(t *testing.T) {
+        invalidPath := filepath.Join(tmpDir, "nonexistent", "lifecycle.id")
+        generator := NewLifecycleIDGenerator(invalidPath)
+        id := generator.Generate()
+        if id == "" {
+            t.Error("Should generate ID even with invalid path")
+        }
+    })
+
+    t.Run("creates directory if not exists", func(t *testing.T) {
+        newDir := filepath.Join(tmpDir, "newdir")
+        filePath := filepath.Join(newDir, "lifecycle.id")
+        generator := NewLifecycleIDGenerator(filePath)
+        generator.Generate()
+        
+        if _, err := os.Stat(newDir); os.IsNotExist(err) {
+            t.Error("Directory should have been created")
+        }
+    })
+}

--- a/agent/main.go
+++ b/agent/main.go
@@ -42,6 +42,11 @@ var (
 			"",
 			"The version of the shepherd project",
 		),
+		LifecycleIDFilePath: config.Define(
+			"life-cycle-id-file-path",
+			"/mnt/data/lifecycle_id",
+			"The file path to store the life cycle id",
+		),
 	}
 )
 
@@ -51,12 +56,13 @@ func main() {
 	log.Printf("Starting agent with name %s", cfg.Name.MustValue())
 
 	agent, err := agent.NewAgent(agent.AgentConfig{
-		Name:              cfg.Name.MustValue(),
-		BackendAddr:       cfg.BackendAddr.MustValue(),
-		BearerToken:       cfg.BearerToken.MustValue(),
-		HeartbeatInterval: cfg.HeartbeatInterval.MustValue(),
-		PlanInterval:      cfg.PlanInterval.MustValue(),
-		VersionID:         cfg.Version.MustValue(),
+		Name:                cfg.Name.MustValue(),
+		BackendAddr:         cfg.BackendAddr.MustValue(),
+		BearerToken:         cfg.BearerToken.MustValue(),
+		HeartbeatInterval:   cfg.HeartbeatInterval.MustValue(),
+		PlanInterval:        cfg.PlanInterval.MustValue(),
+		VersionID:         	 cfg.Version.MustValue(),
+		LifecycleIDFilePath: cfg.LifecycleIDFilePath.MustValue(),
 	})
 	if err != nil {
 		log.Fatalf("Failed to create agent: %s", err)
@@ -68,10 +74,11 @@ func main() {
 }
 
 type Config struct {
-	Name              *config.ConfigVar[string]
-	BearerToken       *config.ConfigVar[string]
-	BackendAddr       *config.ConfigVar[string]
-	HeartbeatInterval *config.ConfigVar[time.Duration]
-	PlanInterval      *config.ConfigVar[time.Duration]
-	Version           *config.ConfigVar[string]
+	Name              	*config.ConfigVar[string]
+	BearerToken       	*config.ConfigVar[string]
+	BackendAddr       	*config.ConfigVar[string]
+	HeartbeatInterval 	*config.ConfigVar[time.Duration]
+	PlanInterval      	*config.ConfigVar[time.Duration]
+	Version           	*config.ConfigVar[string]
+	LifecycleIDFilePath *config.ConfigVar[string]
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -236,6 +236,7 @@ github.com/denis-tingaikin/go-header v0.5.0/go.mod h1:mMenU5bWrok6Wl2UsZjy+1okeg
 github.com/denisenkom/go-mssqldb v0.9.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/docker/cli v25.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
+github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvyukov/go-fuzz v0.0.0-20210103155950-6a8e9d1f2415/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
@@ -380,6 +381,7 @@ github.com/mistifyio/go-zfs/v3 v3.0.1/go.mod h1:CzVgeB0RvF2EGzQnytKVvVSDwmKJXxkO
 github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
 github.com/moby/sys/signal v0.7.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
@@ -532,7 +534,6 @@ golang.org/x/net v0.28.0/go.mod h1:yqtgsTWOOnlGLG9GFRrK3++bGOUEkNBoHZc8MEDWPNg=
 golang.org/x/net v0.29.0/go.mod h1:gLkgy8jTGERgjzMic6DS9+SP0ajcu6Xu3Orq/SpETg0=
 golang.org/x/oauth2 v0.22.0 h1:BzDx2FehcG7jJwgWLELCdmLuxk2i+x9UDpSiss2u0ZA=
 golang.org/x/oauth2 v0.22.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
-golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
Worst case scenario with lifecycle id it will just pick a new id each time it restarts.

SessionID is what lifecycle id used to be. Lifecycle id should now persist each between each deploy.