### PR TITLE
Fix deployment and statefulset yamls

### DIFF
--- a/web/sidecar/chart/templates/service/templates/deployment.yaml
+++ b/web/sidecar/chart/templates/service/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           ports:
             {{- range .Values.services }}
             - name: {{ .name }}

--- a/web/sidecar/chart/templates/service/templates/statefulset.yaml
+++ b/web/sidecar/chart/templates/service/templates/statefulset.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           ports:
             {{- range .Values.services }}
             - name: {{ .name }}

--- a/web/spec/integration/upgrades_spec.rb
+++ b/web/spec/integration/upgrades_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'Upgrades' do
   end
 
   it 'upgrades a subscriber', uses_transactional_fixtures: false, truncate: true do
+    lifecycle_id = subscriber.agent_instances.last.lifecycle_id
     new_version = version.reload.fork!(version: '0.0.2')
     new_version
       .services
@@ -41,5 +42,8 @@ RSpec.describe 'Upgrades' do
     subscriber.assign_to_new_version!(new_version)
 
     wait_for_agent_to_come_online(subscriber)
+
+    expect(subscriber.agent_instances.reload.last.lifecycle_id).to eq(lifecycle_id)
+    expect(subscriber.agent_instances.count).to eq(1)
   end
 end


### PR DESCRIPTION
Both did not respect values.yaml choice of pullpolicy.

Updated test to confirm that there is only one agent instance created (ie upgrade is not treated like two different agents.)