### PR TITLE
Fix predeploy cmd in the agent.

### DIFF
--- a/web/sidecar/chart/params.go
+++ b/web/sidecar/chart/params.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"agent/cluster"
+	"sidecar/chart/predeploycmd"
 	"sidecar/generated/sidecar_pb"
 	"sidecar/values"
 
@@ -109,9 +110,12 @@ type InitConfig struct {
 func (i InitConfig) toValues() map[string]interface{} {
 	m := []map[string]interface{}{}
 	for i, v := range i.InitCommands {
+		predeploycmd, _ := predeploycmd.New(v)
+		command := predeploycmd.Generate()
+
 		m = append(m, map[string]interface{}{
 			"name":    fmt.Sprintf("init-command-%d", i),
-			"command": strings.Split(v, " "),
+			"command": command,
 		})
 	}
 	return map[string]interface{}{

--- a/web/sidecar/chart/params_test.go
+++ b/web/sidecar/chart/params_test.go
@@ -56,7 +56,7 @@ func TestParams_toValues(t *testing.T) {
 					"initCommands": []map[string]interface{}{
 						{
 							"name":    "init-command-0",
-							"command": []string{"ls"},
+							"command": []string{"/bin/sh", "-c", "ls"},
 						},
 					},
 				},
@@ -196,7 +196,7 @@ func TestParams_toValues(t *testing.T) {
 					"initCommands": []map[string]interface{}{
 						{
 							"name":    "init-command-0",
-							"command": []string{"ls"},
+							"command": []string{"/bin/sh", "-c", "ls"},
 						},
 					},
 				},
@@ -286,6 +286,8 @@ ingress:
 initConfig:
   initCommands:
   - command:
+    - /bin/sh
+    - -c
     - ls
     name: init-command-0
 metaEnvironmentFields:

--- a/web/sidecar/chart/predeploycmd/predeploycmd.go
+++ b/web/sidecar/chart/predeploycmd/predeploycmd.go
@@ -1,0 +1,14 @@
+package predeploycmd
+
+
+type PreDeployCmd struct {
+    command string
+}
+
+func New(command string) (*PreDeployCmd, error) {
+    return &PreDeployCmd{command: command}, nil
+}
+
+func (p *PreDeployCmd) Generate() []string {
+    return []string{"/bin/sh", "-c", p.command}
+}

--- a/web/sidecar/chart/predeploycmd/predeploycmd_test.go
+++ b/web/sidecar/chart/predeploycmd/predeploycmd_test.go
@@ -1,0 +1,47 @@
+package predeploycmd
+
+import (
+	"testing"
+)
+
+
+func TestPreDeployCmd_Generate(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    []string
+	}{
+		{
+			name:    "test",
+			command: "echo test",
+			want:    []string{"/bin/sh", "-c", "echo test"},
+		},
+		{
+			name:    "test with quotes",
+			command: "echo \"hello world\"",
+			want:   []string{"/bin/sh", "-c", "echo \"hello world\""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PreDeployCmd{
+				command: tt.command,
+			}
+			if got := p.Generate(); !equal(got, tt.want) {
+				t.Errorf("PreDeployCmd.Generate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/web/sidecar/chart/templates/service/templates/deployment.yaml
+++ b/web/sidecar/chart/templates/service/templates/deployment.yaml
@@ -31,7 +31,10 @@ spec:
         {{- range .Values.initConfig.initCommands }}
         - name: {{ .name }}
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
-          command: {{ .command }}
+          command:
+            {{- range .command }}
+            - {{ . | quote }}
+            {{- end }}
         {{- end }}
       {{- end }}
       containers:

--- a/web/sidecar/chart/templates/service/templates/statefulset.yaml
+++ b/web/sidecar/chart/templates/service/templates/statefulset.yaml
@@ -31,7 +31,10 @@ spec:
         {{- range .Values.initConfig.initCommands }}
         - name: {{ .name }}
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
-          command: {{ .command }}
+          command:
+            {{- range .command }}
+            - {{ . | quote }}
+            {{- end }}
         {{- end }}
       {{- end }}
       containers:

--- a/web/sidecar/server/testdata/TestServer_PublishChart/valid_chart_with_single_service/test-repo/test-chart/charts/test-service/values.yaml
+++ b/web/sidecar/server/testdata/TestServer_PublishChart/valid_chart_with_single_service/test-repo/test-chart/charts/test-service/values.yaml
@@ -7,6 +7,8 @@ ingress:
 initConfig:
   initCommands:
   - command:
+    - /bin/sh
+    - -c
     - ls
     name: init-command-0
 metaEnvironmentFields:


### PR DESCRIPTION
k8s command has to
1. be an array and not a simple string as before
2. must be prepended with bin/sh so it knows what to do with it.

Fixes CTX-562